### PR TITLE
Handle the case with more than 3 fncnt findings

### DIFF
--- a/analyzemft/mft.py
+++ b/analyzemft/mft.py
@@ -300,6 +300,8 @@ def mft_to_csv(record, ret_header,options):
         tmp_string = ['','','','','','','','','','']
     elif record['fncnt'] == 3:
         tmp_string = ['','','','','']
+    else:
+        tmp_string = []
 
     csv_string.extend(tmp_string)
 


### PR DESCRIPTION
Because tmp_string is defined above, when we don't override it then we end up pushing incorrect data to csv_string