### PR TITLE
Nanosecond fix

### DIFF
--- a/analyzemft/mft.py
+++ b/analyzemft/mft.py
@@ -782,12 +782,7 @@ def anomaly_detect(record):
         except:
             record['stf-fn-shift'] = True
 
-        # Check for STD create times with a nanosecond value of '0'
-        if record['fn', 0]['crtime'].dt != 0:
-            if record['fn', 0]['crtime'].dt.microsecond == 0:
-                record['usec-zero'] = True
-
-        
+        # Check for STD create times with a nanosecond value of '0'     
         try:
             if record['si']['crtime'].dt != 0:
                 if record['si']['crtime'].dt.microsecond == 0:

--- a/analyzemft/mft.py
+++ b/analyzemft/mft.py
@@ -786,3 +786,11 @@ def anomaly_detect(record):
         if record['fn', 0]['crtime'].dt != 0:
             if record['fn', 0]['crtime'].dt.microsecond == 0:
                 record['usec-zero'] = True
+
+        
+        try:
+            if record['si']['crtime'].dt != 0:
+                if record['si']['crtime'].dt.microsecond == 0:
+                    record['usec-zero'] = True
+        except:
+            pass


### PR DESCRIPTION
Hi David,

Please have a look at these changes to address the issue with nanosecond anomaly detection.  It was previously checking the $FN creation time rather than the $SI creation time.  It now works correctly on the SANS nromanoff C:\WIndows\System32\dllhost\svchost.exe example, per issue #45.

I also added a try/except  to check if an SI creation time exists at all--and if not, ignore this check.  Sometimes it will not (ref SANS  nromanoff image, MFT record 9837).  

So, if SI create doesn't exist, or if it does exist but has a fractional second value, then record['usec-zero'] will remain undefined, and the "uSec Zero" column gets an "N".  If it does exist and is NOT a fractional second value, then it gets a "Y".

Example screenshot below.  I can post all the parsed data from nromanoff elsewhere if you like, but it's too big for GitHub (at least here in the pull request).

![nromanoff_nanosec_fix](https://user-images.githubusercontent.com/5453480/36616194-79eba220-18a8-11e8-8a97-6a93af5967b5.PNG)

Thanks,
Mike