### PR TITLE
Copy move

### DIFF
--- a/analyzemft/mft.py
+++ b/analyzemft/mft.py
@@ -802,7 +802,6 @@ def anomaly_detect(record):
             pass
 
         # Check for STD create times that are after the STD modify times.  This is often the result of a file copy.
-
         try:
             if record['si']['crtime'].dt > record['si']['mtime'].dt:
                 record['possible-copy'] = True
@@ -811,7 +810,6 @@ def anomaly_detect(record):
 
         # Check for STD access times that are after the STD modify and STD create times.  For systems with last access 
         # timestamp disabled (Windows Vista+), this is an indication of a file moved from one volume to another.
-
         try:
             if record['si']['atime'].dt > record['si']['mtime'].dt and record['si']['atime'].dt > record['si']['crtime'].dt:
                 record['possible-volmove'] = True

--- a/analyzemft/mft.py
+++ b/analyzemft/mft.py
@@ -246,7 +246,8 @@ def mft_to_csv(record, ret_header, options):
                       'FN Info Entry date', 'Standard Information', 'Attribute List', 'Filename',
                       'Object ID', 'Volume Name', 'Volume Info', 'Data', 'Index Root',
                       'Index Allocation', 'Bitmap', 'Reparse Point', 'EA Information', 'EA',
-                      'Property Set', 'Logged Utility Stream', 'Log/Notes', 'STF FN Shift', 'uSec Zero', 'ADS']
+                      'Property Set', 'Logged Utility Stream', 'Log/Notes', 'STF FN Shift', 'uSec Zero',
+                      'ADS', 'Possible Copy', 'Possible Volume Move']
         return csv_string
 
     if 'baad' in record:
@@ -375,6 +376,16 @@ def mft_to_csv(record, ret_header, options):
         csv_string.append('N')
 
     if record['ads'] > 0:
+        csv_string.append('Y')
+    else:
+        csv_string.append('N')
+
+    if 'possible-copy' in record:
+        csv_string.append('Y')
+    else:
+        csv_string.append('N')
+
+    if 'possible-volmove' in record:
         csv_string.append('Y')
     else:
         csv_string.append('N')
@@ -787,5 +798,22 @@ def anomaly_detect(record):
             if record['si']['crtime'].dt != 0:
                 if record['si']['crtime'].dt.microsecond == 0:
                     record['usec-zero'] = True
+        except:
+            pass
+
+        # Check for STD create times that are after the STD modify times.  This is often the result of a file copy.
+
+        try:
+            if record['si']['crtime'].dt > record['si']['mtime'].dt:
+                record['possible-copy'] = True
+        except:
+            pass
+
+        # Check for STD access times that are after the STD modify and STD create times.  For systems with last access 
+        # timestamp disabled (Windows Vista+), this is an indication of a file moved from one volume to another.
+
+        try:
+            if record['si']['atime'].dt > record['si']['mtime'].dt and record['si']['atime'].dt > record['si']['crtime'].dt:
+                record['possible-volmove'] = True
         except:
             pass


### PR DESCRIPTION
Hello David,

I created 2 new checks for anomaly detection to flag possible file copies and file volume moves.  These checks were suggested in Issue #46.

Here's a screenshot against SANS nromanoff image.  This is filtered on Filename containing "svchost.exe", which includes the timestomped c:\Windows\System32\dllhost\svchost.exe malware.  Note that "Possible Volume Move" flag is set on this file because the attacker did not backdate the access timestamp--only the create & modify times--so it appears to be a volume move file.

![image](https://user-images.githubusercontent.com/5453480/37177772-0c20b3fa-22e6-11e8-9b11-b26d05255010.png)

Thanks,
Mike